### PR TITLE
Couple of suggested changes

### DIFF
--- a/website/docs/02-organising-data/documents-instances.md
+++ b/website/docs/02-organising-data/documents-instances.md
@@ -24,7 +24,7 @@ id: documents
 - a _document view_ is the result of applying a series of operations from a _document_
   - the series of operations must start with the document's _create operation_
   - see [reduction](/docs/organising-data/reduction) and [reconciliation](/docs/collaboration/reconciliation) for further details
-- a document view is identified by it's documents current graph tips
+- a document view is identified by its document's current graph tips
   - the graph tips themselves are expressed as a list of operation ids
 - a document view has a value for all fields that are defined by its document's schema
 - a document view is _deleted_ if its document contains a _delete operation_

--- a/website/docs/02-organising-data/documents-instances.md
+++ b/website/docs/02-organising-data/documents-instances.md
@@ -24,7 +24,7 @@ id: documents
 - a _document view_ is the result of applying a series of operations from a _document_
   - the series of operations must start with the document's _create operation_
   - see [reduction](/docs/organising-data/reduction) and [reconciliation](/docs/collaboration/reconciliation) for further details
-- a document view is identified by its document's current graph tips
+- a document view is identified by its document's graph tips
   - the graph tips themselves are expressed as a list of operation ids
 - a document view has a value for all fields that are defined by its document's schema
 - a document view is _deleted_ if its document contains a _delete operation_

--- a/website/docs/02-organising-data/documents-instances.md
+++ b/website/docs/02-organising-data/documents-instances.md
@@ -24,7 +24,7 @@ id: documents
 - a _document view_ is the result of applying a series of operations from a _document_
   - the series of operations must start with the document's _create operation_
   - see [reduction](/docs/organising-data/reduction) and [reconciliation](/docs/collaboration/reconciliation) for further details
-- a document view is identified by its _previous operations_
-  - _previous operations_ is a list of operation ids that identify the graph tips of the document graph
+- a document view is identified by it's documents current graph tips
+  - the graph tips themselves are expressed as a list of operation ids
 - a document view has a value for all fields that are defined by its document's schema
 - a document view is _deleted_ if its document contains a _delete operation_

--- a/website/docs/02-organising-data/reduction.md
+++ b/website/docs/02-organising-data/reduction.md
@@ -4,18 +4,18 @@ id: reduction
 
 # Reduction
 
-- reduction is the process of creating an _instance_ from a _document_ (c.f. [documents and views](/docs/organising-data/documents))
+- reduction is the process of creating an _document view_ from a _document_ (c.f. [documents and views](/docs/organising-data/documents))
 
 ## Algorithm
 
 - preprocess the document graph by applying topological sorting to linearise the operation graph
 
-1. Deserialise all fields of the document's _create operation_ to produce an _instance_
+1. Deserialise all fields of the document's _create operation_ to produce an _document view_
 2. If the next operation in the document is an _update operation_
    - for every field in the operation
-     - overwrite this field's contents on the instance with the contents from the operation
+     - overwrite this field's contents on the view with the contents from the operation
 3. If the next operation in the document is a _delete operation_
-   - remove the content on all fields of the instance
-   - mark the instance deleted
+   - remove the content on all fields of the view
+   - mark the view deleted
 4. Stop reduction if there is no next known operation in the document
 5. Continue with step 2. otherwise


### PR DESCRIPTION
I think these two things should be changed, let me know if you agree :+1:

- a couple of places where we still refer to "instances"
- I feel it's a bit confusing to say that views are identified by their "previous operations". The concept of previous operations is tied to the next operation which is not published yet, so I feel it's better to say the view is identified by the current document graph tips.