### PR TITLE
Add github action to deploy `p2panda-js` API documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,9 @@ name: Deploy website via GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    # TODO: Comment this out for now
+    # branches:
+    #   - main
 
 defaults:
   run:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,18 +61,19 @@ jobs:
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        working-directory: p2panda-js
 
       - name: Install dependencies
         run: npm ci
-        working-directory: ${{ env.working_directory }}
+        working-directory: p2panda-js
 
       - name: Build documentation page
         run: npm run docs
-        working-directory: ${{ env.working_directory }}
+        working-directory: p2panda-js
 
       - name: Deploy website
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.working_directory }}/docs
+          publish_dir: p2panda-js/docs
           destination_dir: lib/p2panda-js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   deploy:
-    name: Deploy
+    name: Deploy p2panda website
 
     runs-on: ubuntu-latest
 
@@ -43,7 +43,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/build
 
-  js-docs:
+  deploy-js-docs:
     name: Deploy p2panda-js API documentation
 
     runs-on: ubuntu-latest
@@ -65,6 +65,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        working-directory: p2panda-js
+
+      - name: Compile wasm and build p2panda-js
+        run: npm run build
         working-directory: p2panda-js
 
       - name: Build documentation page

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 defaults:
   run:
@@ -13,11 +12,12 @@ defaults:
 jobs:
   deploy:
     name: Deploy
+
     runs-on: ubuntu-latest
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v2
@@ -41,3 +41,37 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/build
+
+  js-docs:
+    name: Deploy p2panda-js API documentation
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout p2panda-js repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'p2panda/p2panda'
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ${{ env.working_directory }}
+
+      - name: Build documentation page
+        run: npm run docs
+        working-directory: ${{ env.working_directory }}
+
+      - name: Deploy website
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.working_directory }}/docs
+          destination_dir: lib/p2panda-js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,8 @@ name: Deploy website via GitHub Pages
 
 on:
   push:
-    # TODO: Comment this out for now
-    # branches:
-    #   - main
+    branches:
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
This deploys the `p2panda-js` TypeDoc documentation under https://p2panda.org/handbook/lib/p2panda-js/ (later without "handbook" when we release the website).

> :teapot: Please note: The page is currently not visible as the GH action only gets triggered on pushes on `main`. I promise you the documentation looks cool.

I've tried to dispatch the deploy task automatically from whenever there is a new commit in `p2panda`, sadly that only works with personal authentication tokens and I think thats too much to ask everyone on the team to generate their tokens (and re-generated their expired ones x months) just for that. 

To update the documentation one must manually re-trigger the workflow _or_ of course push something to `main`, though I assume that the first option is "better".

I can see a potential *"oups, I forgot to update the documentation, its outdated!"* with this sort of setup and I'm happy to hear any suggestions for a better plan? :sweat_smile: 

Closing: #181 