### PR TITLE
Add requirements and definitions to `entry` and `operation` pages

### DIFF
--- a/website/docs/specification/data-types/bamboo.md
+++ b/website/docs/specification/data-types/bamboo.md
@@ -3,38 +3,75 @@ id: bamboo
 title: Bamboo
 ---
 
-- in order to write data in p2panda it needs to be encoded
-- p2panda uses [bamboo][bamboo_spec] to encode data
-  - this handbook doesn't repeat everything that's in the bamboo spec, so it might be helpful to have a look at that (it's not too long)
-- bamboo is an append-only data structure that allows encoding arbitrary data in order to share it among peers without trust in the data transmission
-  - bamboo organises data by _author_
-  - every author has many [_logs_](#logs), each of which contains many _entries_
-  - entries are the container for individual pieces of data that we want to publish
-  - the following sections explain how these concepts from bamboo are used in p2panda
-- p2panda uses bamboo with [_yasmf_ hashes](https://github.com/bamboo-rs/yasmf-hash)
+:::note Requirement BA1
+
+p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
+
+:::
+
+- p2panda is built on [bamboo][bamboo_spec] as the data structure that is used to encode data.
+  - This handbook doesn't repeat everything that's in the bamboo spec, so it might be helpful to have a look at that (it's not too long).
+- Bamboo is an append-only data structure that allows encoding arbitrary data in order to share it among peers without trust in the data transmission.
+  - Bamboo organises data by _author_
+  - Every author has many [_logs_](#logs), each of which contains many _entries_.
+  - Entries are containers for atomic pieces of data that we want to publish.
+  - The following sections explain how these concepts from bamboo are used in p2panda
+
+### Hashing
+
+:::note Requirement BA2
+
+[_Yet Another Smol Multifactor Hash_ (YASMF)][yasmf] MUST be used to produce hashes for Bamboo entries and payloads.
+
+:::
+
+- The original Bamboo requires [_YAMF-hashes_][yamf] to verify the integrity of entries and logs.
+  - YAMF is a multiformat hash that only adds new hash functions when previous once have been discovered to be broken.
+- However, p2panda uses bamboo with [_YASMF_-hashes][yasmf].
+  - YASMF has the additional requirement that hash functions should be chosen that produce shorter hashes.
+  - At the time of writing, YASMF only contains the Blake3b hash, which therefore is the hash function used throughout p2panda. It is fast, safe, and produces hashes that are just 32 bytes long.
+
+### Encoding
+
+:::note Requirement BA3
+
+Bamboo entries MUST be encoded using hexadecimal encoding with lowercase characters. Each byte of the Bamboo entry MUST be encoded using two hexadecimal digits.
+
+:::
+
+- p2panda uses hex-encoding to make it nicer for humans to look at the data.
 
 ### Authors
 
-- data published using bamboo always belongs to the public key that signed it, this key is called _author_ in bamboo
-- people who use p2panda can have access to more than one key pair, which is why we don't call public keys _author_, as bamboo does, we call them _public key_
-  - p2panda users may have more than one key because every device uses an additional key
-- have a look at the [key pairs][key_pairs] section of this handbook for more detailed information on this topic
+:::info Definition: Author
+
+A p2panda author is a human or bot who publishes data using p2panda. Authors may have more than one key pair.
+
+:::
+
+- Data published using Bamboo always belongs to the public key that signed it, this key is called _author_ in Bamboo.
+- People and bots who use p2panda can have access to more than one key pair, which is why we don't call public keys _author_, as Bamboo does, we call them _public key_.
+  - Data in p2panda belongs to the _key pair_ that signed it.
+  - p2panda users may have more than one key because every device uses an additional key.
+- Have a look at the [key pairs][key_pairs] section of this handbook for more detailed information on this topic.
 
 ### Logs
 
-- when a _bamboo author_ publishes data they assign it to a log, which is identified by an integer number
-  - every author has 2^64 logs available to them
-- in p2panda every log is used to collect a key pair's contributions to one [document][documents]
-- every log contains up to 2^64 - 1 entries
+- When a key pair publishes data it is assigned to a Bamboo _log_, which is identified by an integer number.
+  - Every key pair has 2^64 logs available to them.
+- In p2panda every Bamboo log is used to collect a key pair's contributions to one [document][documents].
+- Every log contains up to 2^64 - 1 entries.
 
 ### Entries
 
-- p2panda uses Bamboo entries to record changes of data while giving us cool features like partial replication, cryptographic integrity and authenticity
-  - every individual change is recorded inside an entry
-  - we call these changes _operations_
-- have a look at the [operations][operations] section of this handbook for more detailled information on this topic
+- p2panda uses Bamboo entries to record changes of data while giving us cool features like partial replication, cryptographic integrity and authenticity.
+  - Every atomic change is recorded inside an entry.
+  - We call these changes _operations_.
+- Have a look at the [operations][operations] section of this handbook for more detailled information on this topic.
 
 [key_pairs]: /specification/data-types/key-pairs
 [bamboo_spec]: https://github.com/bamboo-rs/bamboo-ed25519-yasmf
+[yamf]: https://github.com/AljoschaMeyer/yamf-hash
+[yasmf]: https://github.com/bamboo-rs/yasmf-hash
 [documents]: /specification/data-types/documents
 [operations]: /specification/data-types/operations

--- a/website/docs/specification/data-types/bamboo.md
+++ b/website/docs/specification/data-types/bamboo.md
@@ -3,6 +3,8 @@ id: bamboo
 title: Bamboo
 ---
 
+- requirements in this section refer only to how p2panda specifies use of bamboo
+
 :::note Requirement BA1
 
 p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
@@ -35,7 +37,7 @@ p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
 
 :::note Requirement BA3
 
-Bamboo entries MUST be encoded using hexadecimal encoding with lowercase characters. Each byte of the Bamboo entry MUST be encoded using two hexadecimal digits.
+Bamboo entries MUST be encoded using hexadecimal encoding.
 
 :::
 
@@ -68,6 +70,10 @@ A p2panda author is a human or bot who publishes data using p2panda. Authors may
   - Every atomic change is recorded inside an entry.
   - We call these changes _operations_.
 - Have a look at the [operations][operations] section of this handbook for more detailled information on this topic.
+
+### End of log flag
+
+- Currently p2panda doesn't reserve a special use for the end of log flag. This may change in future versions.
 
 [key_pairs]: /specification/data-types/key-pairs
 [bamboo_spec]: https://github.com/bamboo-rs/bamboo-ed25519-yasmf

--- a/website/docs/specification/data-types/encoding.md
+++ b/website/docs/specification/data-types/encoding.md
@@ -1,0 +1,32 @@
+---
+id: encoding-data
+title: Encoding
+---
+
+### Hexadecimal
+
+:::note Requirement EN1
+
+Unless otherwise specified hexadecimal encoding MUST use lowercase charachters. Each byte MUST be encoded using two hexadecimal digits.
+
+:::
+
+### CBOR
+
+- p2panda requires a canonical encoding format to guarantee that hashing a value produces the same hash every time it is encoded, for all implementations. To achieve this we add some requirements on top of the CBOR specification.
+
+:::note Requirement EN2
+
+All CBOR array values and map keys whose order is not semantic MUST be encoded in lexicographically sorted order.
+
+:::
+
+:::note Requirement EN3
+
+All CBOR map keys MUST be unique.
+
+:::
+
+### Conventions
+
+- p2panda prefers [snake case][snake_case] for field names.

--- a/website/docs/specification/data-types/encoding.md
+++ b/website/docs/specification/data-types/encoding.md
@@ -3,7 +3,7 @@ id: encoding-data
 title: Encoding
 ---
 
-### Hexadecimal
+## Hexadecimal
 
 :::note Requirement EN1
 
@@ -11,7 +11,7 @@ Unless otherwise specified hexadecimal encoding MUST use lowercase charachters. 
 
 :::
 
-### CBOR
+## CBOR
 
 - p2panda requires a canonical encoding format to guarantee that hashing a value produces the same hash every time it is encoded, for all implementations. To achieve this we add some requirements on top of the CBOR specification.
 
@@ -27,6 +27,16 @@ All CBOR map keys MUST be unique.
 
 :::
 
+## WIP SECTIONS
+
 ### Conventions
 
 - p2panda prefers [snake case][snake_case] for field names.
+
+### Prelude
+
+- this p2panda specification represents the operation specification version 1
+
+### Publishing / recieving data
+
+- unknown or unsupported operation versions MUST be rejected.

--- a/website/docs/specification/data-types/encoding.md
+++ b/website/docs/specification/data-types/encoding.md
@@ -19,6 +19,12 @@ Unless otherwise specified hexadecimal encoding MUST use lowercase charachters. 
 
 All CBOR array values and map keys whose order is not semantic MUST be encoded in lexicographically sorted order.
 
+Arrays without semantic meaning, which therefore need sorting, are:
+
+- any _document view id_
+  - incluing those in a _schema id_ or _pinned_relation_
+- _previous_ operation array in an operation
+
 :::
 
 :::note Requirement EN3
@@ -26,17 +32,3 @@ All CBOR array values and map keys whose order is not semantic MUST be encoded i
 All CBOR map keys MUST be unique.
 
 :::
-
-## WIP SECTIONS
-
-### Conventions
-
-- p2panda prefers [snake case][snake_case] for field names.
-
-### Prelude
-
-- this p2panda specification represents the operation specification version 1
-
-### Publishing / recieving data
-
-- unknown or unsupported operation versions MUST be rejected.

--- a/website/docs/specification/data-types/key-pairs.md
+++ b/website/docs/specification/data-types/key-pairs.md
@@ -3,23 +3,43 @@ id: key-pairs
 title: Key Pairs
 ---
 
-- clients sign all published data with a user's key pair
-- p2panda uses Ed25519 key pairs
+:::note Requirement KY1
+
+Key pairs must use ED25519 keys.
+
+:::
+
+- A key pair is used to sign Bamboo entries and their payloads.
+- The public key of a key pair is embedded in Bamboo entries and therefore always available when verifying an entry and its payload.
 
 ## Usage
 
 - p2panda clients create key pairs for their users
-  - the p2panda library includes functionality to create key pairs
-- data recipients can identify the author of data from the public key and the signature on a [bamboo entry](/specification/data-types/bamboo#entries)
-  - the public key and signature are distributed alongside the data
-- data recipients can verify the integrity of data using the signature on bamboo entries
+- Data recipients can identify the author of data from the public key and the signature on a [bamboo entry](/specification/data-types/bamboo#entries).
+  - The public key and signature are distributed alongside the data.
+- Data recipients can verify the integrity of data using the signature on bamboo entries.
 
 ## Key Management
 
-- p2panda clients SHOULD generate a new key pair for every new usage context
-  - the boundaries of a usage context are defined by
-    - device storage
-    - software distribution
-    - trust
-- p2panda clients SHOULD ensure that private keys cannot be read by adversaries
-- p2panda clients SHOULD NOT require the transmission of a private key outside a usage context (e.g. to migrate a software installation)
+:::note Requirement KY2
+
+p2panda clients SHOULD generate a new key pair for every new usage context. The boundaries of a usage context are defined by 1) device storage, 2) software distribution and 3) trust.
+
+:::
+
+- This lowers the chance of producing a fork in a Bamboo log.
+  - A Bamboo log has a fork when two entries with the same sequence number exist in it.
+
+:::note Requirement KY3
+
+p2panda clients SHOULD ensure that private keys cannot be read by adversaries.
+
+:::
+
+:::note Requirement KY4
+
+p2panda clients SHOULD NOT require the transmission of a private key outside a usage context.
+
+:::
+
+- Transmitting a private key outside of its usage context might be attractive e.g. to migrate a software installation but it is considered a security risk, can lead to forks and hard to get right in terms of user experience.

--- a/website/docs/specification/data-types/key-pairs.md
+++ b/website/docs/specification/data-types/key-pairs.md
@@ -5,9 +5,13 @@ title: Key Pairs
 
 :::note Requirement KY1
 
-Key pairs must use ED25519 keys.
+Key pairs MUST use ED25519 keys.
 
 :::
+
+
+
+Correct hexadecimal encoding (when using human-readable encoding format) (#OP1)
 
 - A key pair is used to sign Bamboo entries and their payloads.
 - The public key of a key pair is embedded in Bamboo entries and therefore always available when verifying an entry and its payload.

--- a/website/docs/specification/data-types/operations.md
+++ b/website/docs/specification/data-types/operations.md
@@ -17,43 +17,42 @@ The _operation id_ uniquely identifies an operation. It is equal to the hash of 
 
 :::note Requirement OP1
 
-Operations MUST be encoded using CBOR.
+Operations MUST be encoded using hexadecimal encoded CBOR.
 
 :::
 
 - CBOR is a binary encoding that is used to encode the contents of an operation and produce bytes that can be associated with a Bamboo entry, stored, and sent over a network connection.
-- p2panda prefers [snake case][snake_case] for field names.
 
 :::note Requirement OP2
 
-All array values and map keys whose order is not semantic MUST be encoded in lexicographically sorted order.
+An operation must be encoded as a CBOR array containing the following items in this exact order:
+
+1. Version
+2. Action
+3. Schema
+4. Previous (optional)
+5. Fields (optional)
 
 :::
 
-:::note Requirement OP3
+## Operation Action
 
-Map keys MUST be unique.
+- The operation action defines the kind of data change that is described by the operation.
 
-:::
+:::note Requirement OP2
 
-## Operation Type
-
-- The operation type defines the kind of data change that is described by the operation.
-
-:::note Requirement OP4
-
-An operation MUST have an operation type. An operation type MUST be one of `CREATE`, `UPDATE`, `DELETE`.
+An operation MUST have an operation action. An operation action MUST be one of `CREATE`, `UPDATE`, `DELETE`.
 
 :::
 
-- Every operation type results in a different kind of operation:
+- Every operation action results in a different kind of operation:
   - `CREATE` - results in a _create operation_
   - `UPDATE` - results in a _update operation_
   - `DELETE` - results in a _delete operation_
 
 ## Operation Schema
 
-:::note Requirement OP5
+:::note Requirement OP3
 
 Every operation MUST have a schema.
 

--- a/website/docs/specification/data-types/operations.md
+++ b/website/docs/specification/data-types/operations.md
@@ -3,49 +3,133 @@ id: operations
 title: Operations
 ---
 
-- operations represent data changes
-- operations are published as the payload of _bamboo entries_
-- operations are identified by the hash of their bamboo entry
-  - this is referred to as the _operation id_
-- every operation is associated with a [bamboo author](/specification/data-types/key-pairs), which is encoded in the operation's _entry_
-- every operation MUST have an _operation type_, which must be one of
+- Operations represent atomic data changes.
+- Operations are published as the payload of _bamboo entries_.
+- Operations are identified by the hash of their bamboo entry.
+
+:::info Definition: Operation ID
+
+The _operation id_ uniquely identifies an operation. It is equal to the hash of the Bamboo entry that has the operation as its payload.
+
+:::
+
+## Encoding
+
+:::note Requirement OP1
+
+Operations MUST be encoded using CBOR.
+
+:::
+
+- CBOR is a binary encoding that is used to encode the contents of an operation and produce bytes that can be associated with a Bamboo entry, stored, and sent over a network connection.
+- p2panda prefers [snake case][snake_case] for field names.
+
+:::note Requirement OP2
+
+All array values and map keys whose order is not semantic MUST be encoded in lexicographically sorted order.
+
+:::
+
+:::note Requirement OP3
+
+Map keys MUST be unique.
+
+:::
+
+## Operation Type
+
+- The operation type defines the kind of data change that is described by the operation.
+
+:::note Requirement OP4
+
+An operation MUST have an operation type. An operation type MUST be one of `CREATE`, `UPDATE`, `DELETE`.
+
+:::
+
+- Every operation type results in a different kind of operation:
   - `CREATE` - results in a _create operation_
   - `UPDATE` - results in a _update operation_
   - `DELETE` - results in a _delete operation_
-- every operation MUST have a [schema](/specification/data-types/schemas)
-- every operation MUST have an _operation version_
-  - it describes the version of the operation specification that is followed by that operation
-  - versions are encoded as integers
-- every _delete_ and _update operation_ MUST have _previous operations_ with `length > 0`
-  - it contains an array of _operation_id_'s which identify the tip operation of any un-merged branches in this document graph
-  - in the case where a graph has no un-merged branches, this array will contain only one id (the resolved graph tip)
-  - publishing an operation which identifies more than 1 graph tip, effectively merges these branches into one
-- a _create operation_ MUST not have _previous operations_
+
+## Operation Schema
+
+:::note Requirement OP5
+
+Every operation MUST have a schema.
+
+:::
+
+- The schema of an operation may define additional requirements for the operation.
+  - See the [schema](/specification/data-types/schemas) section for more details.
+
+## Operation Version
+
+:::note Requirement OP6
+
+Every operation MUST have an _operation version_. An operation version MUST be a positive integer number. An operation version MUST NOT be larger than 256.
+
+:::
+
+- The operation version is set according to the version of the p2panda specification that is followed by that operation.
+
+## Previous Operations
+
+:::note Requirement OP7
+
+Every _update operation_ and every _delete operation_ MUST have _previous operations_. The previous operations of an operation MUST contain all _graph tips_ of the operation's document.
+
+:::
+
+- _Previous operations_ specify where an operation should be placed when constructing the graph of operations required to materialise a document.
+  - It contains an array of _operation_id_'s which identify the tip operation of any un-merged branches in a document graph.
+  - On the case where a graph has no un-merged branches, this array will contain only one id (the resolved graph tip).
+  - Publishing an operation which identifies more than one graph tip effectively merges these branches into one.
+
+:::note Requirement OP8
+
+A create operation MUST NOT have _previous operations_.
+
+:::
 
 ## Fields
 
-- a _create operation_ MUST contain all fields of the operation's schema
-- an _update operation_ MAY contain any combination of fields from the operation's schema
-- a _delete operation_ MUST NOT contain any fields
+- _Operation fields_ contain the actual data carried by an operation.
+- Depending on the operation's type and schema, different requirements exist for which data must be contained in the operation.
 
-## Serialisation
+:::note Requirement OP9
 
-- operations are serialised using [CBOR][cbor]
-- all fields are serialised using [snake case][snake_case]
-- all array values and map keys must be serialised in sorted order unless their order is semantic
-  - all operations that have values or map keys which are not sorted even though their order has no semantic meaning are invalid
+A _create operation_ MUST contain all fields defined by the operation's _operation schema_.
+
+:::
+
+:::note Requirement OP10
+
+An _update operation_ MAY contain any combination of fields from the operation's _operation schema_.
+
+:::
+
+:::note Requirement OP11
+
+A _delete operation_ MUST NOT contain any fields.
+
+:::
 
 ## Usage
 
-- clients can use operations to publish data changes
-- clients must embed operations in bamboo entries to publish them
-- clients can create a [document](/specification/data-types/documents#documents) by publishing a _create operation_
-- clients can update a document by publishing an _update operation_
-  - every _update operation_ leads to a new _document view_ of the document that is being updated
-- clients can delete a document by publishing a _delete operation_
-- nodes can [reduce](/specification/data-types/materialization#reduction) operations to produce a specific _document view_ of their document
-- clients can delete a document by publishing a _delete operation_ 
-  - nodes MUST delete all operations of a document once it has been deleted
+- Clients can use operations to publish data changes.
+- Clients must embed operations in bamboo entries to publish them.
+- Clients can create a [document](/specification/data-types/documents#documents) by publishing a _create operation_.
+- Clients can update a document by publishing an _update operation_.
+  - Every _update operation_ leads to a new _document view_ of the document that is being updated.
+- Clients can delete a document by publishing a _delete operation_.
+- Nodes can [reduce](/specification/data-types/materialization#reduction) operations to produce a specific _document view_ of their document.
+- Clients can delete a document by publishing a _delete operation_.
+
+:::note Requirement OP12
+
+Nodes MUST delete all operations of a document once it has been deleted. (_note: this should probably go into the documents section_).
+
+:::
 
 [cbor]: https://cbor.io/
 [snake_case]: https://en.wikipedia.org/wiki/Snake_case

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "website",
-  "version": "0.0.0",
+  "name": "handbook",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "website",
-      "version": "0.0.0",
+      "name": "handbook",
+      "version": "0.1.0",
       "dependencies": {
         "@docusaurus/core": "2.0.1",
         "@docusaurus/preset-classic": "2.0.1",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -20,6 +20,7 @@ const sidebars = {
       type: 'category',
       label: 'Data types',
       items: [
+        'specification/data-types/encoding-data',
         'specification/data-types/bamboo',
         'specification/data-types/key-pairs',
         'specification/data-types/operations',


### PR DESCRIPTION
- adds requirements and definitions boxes and uses proper casing for sentences
- add encoding page for spec wide encoding requirements