### PR TITLE
Minor changes and clarifications around Bamboo

### DIFF
--- a/website/docs/specification/data-types/bamboo.md
+++ b/website/docs/specification/data-types/bamboo.md
@@ -7,7 +7,7 @@ title: Bamboo
 
 :::caution Requirement BA1
 
-p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
+p2panda uses [Bamboo][bamboo_spec] with Ed25519 (Digital Signature Algorithm) and YASMF (Multihash) to encode and secure data.
 
 :::
 
@@ -23,7 +23,7 @@ p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
 
 :::caution Requirement BA2
 
-[_Yet Another Smol Multifactor Hash_ (YASMF)][yasmf] MUST be used to produce hashes for Bamboo entries and payloads.
+[_Yet Another Smol Multi-Hash (YASMF)][yasmf] MUST be used to produce hashes for Bamboo entries and payloads.
 
 :::
 

--- a/website/docs/specification/data-types/bamboo.md
+++ b/website/docs/specification/data-types/bamboo.md
@@ -3,7 +3,7 @@ id: bamboo
 title: Bamboo
 ---
 
-- requirements in this section refer only to how p2panda specifies use of bamboo
+- requirements in this section refer only to how p2panda specifies use of bamboo.
 
 :::caution Requirement BA1
 
@@ -11,13 +11,13 @@ p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
 
 :::
 
-- p2panda is built on [bamboo][bamboo_spec] as the data structure that is used to encode data.
-  - This handbook doesn't repeat everything that's in the bamboo spec, so it might be helpful to have a look at that (it's not too long).
-- Bamboo is an append-only data structure that allows encoding arbitrary data in order to share it among peers without trust in the data transmission.
-  - Bamboo organises data by _author_
-  - Every author has many [_logs_](#logs), each of which contains many _entries_.
-  - Entries are containers for atomic pieces of data that we want to publish.
-  - The following sections explain how these concepts from bamboo are used in p2panda
+- p2panda is built on top of [Bamboo][bamboo_spec].
+  - This handbook doesn't repeat everything that's in the Bamboo spec, so it might be helpful to have a look at that (it's not too long).
+- Bamboo is an append-only log data type that ensures security and authenticity of arbitrary data in order to share it in a decentralized and trustless setting.
+  - Bamboo organises data by _author_.
+  - Every author can have many [_logs_](#logs), each of which contains many _entries_.
+  - Entries contain p2panda data that we want to publish.
+- The following sections explain how these concepts from bamboo are used in p2panda.
 
 ### Hashing
 
@@ -28,16 +28,24 @@ p2panda uses [Bamboo Ed25519 Yasmf][bamboo_spec] to encode data.
 :::
 
 - The original Bamboo requires [_YAMF-hashes_][yamf] to verify the integrity of entries and logs.
-  - YAMF is a multiformat hash that only adds new hash functions when previous once have been discovered to be broken.
+  - YAMF is a multiformat hash that only adds new hash functions when previous ones have been discovered to be broken.
 - However, p2panda uses bamboo with [_YASMF_-hashes][yasmf].
-  - YASMF has the additional requirement that hash functions should be chosen that produce shorter hashes.
+  - YASMF has the additional requirement that hash functions should be chosen that produce shorter hashes of 256 bits.
   - At the time of writing, YASMF only contains the Blake3b hash, which therefore is the hash function used throughout p2panda. It is fast, safe, and produces hashes that are just 32 bytes long.
+
+### Signatures
+
+:::caution Requirement KY1
+
+Clients MUST use Ed25519 as the Digital Signature Algorithm for Bamboo.
+
+:::
 
 ### Encoding
 
 :::caution Requirement BA3
 
-Bamboo entries MUST be encoded using hexadecimal encoding.
+Bamboo entries MUST be encoded using hexadecimal encoding when being transported through the Client API via GraphQL.
 
 :::
 
@@ -54,7 +62,7 @@ A p2panda author is a human or bot who publishes data using p2panda. Authors may
 - Data published using Bamboo always belongs to the public key that signed it, this key is called _author_ in Bamboo.
 - People and bots who use p2panda can have access to more than one key pair, which is why we don't call public keys _author_, as Bamboo does, we call them _public key_.
   - Data in p2panda belongs to the _key pair_ that signed it.
-  - p2panda users may have more than one key because every device uses an additional key.
+  - p2panda users may have more than one key because every device and client uses an additional key.
 - Have a look at the [key pairs][key_pairs] section of this handbook for more detailed information on this topic.
 
 ### Logs

--- a/website/docs/specification/data-types/bamboo.md
+++ b/website/docs/specification/data-types/bamboo.md
@@ -28,10 +28,10 @@ p2panda uses [Bamboo][bamboo_spec] with Ed25519 (Digital Signature Algorithm) an
 :::
 
 - The original Bamboo requires [_YAMF-hashes_][yamf] to verify the integrity of entries and logs.
-  - YAMF is a multiformat hash that only adds new hash functions when previous ones have been discovered to be broken.
+  - YAMF is a multiformat hash that only adds new hashing algorithms when previous ones have been discovered to be broken.
 - However, p2panda uses bamboo with [_YASMF_-hashes][yasmf].
-  - YASMF has the additional requirement that hash functions should be chosen that produce shorter hashes of 256 bits.
-  - At the time of writing, YASMF only contains the Blake3b hash, which therefore is the hash function used throughout p2panda. It is fast, safe, and produces hashes that are just 32 bytes long.
+  - YASMF has the additional requirement that hashing algorithms should be chosen that produce shorter hashes (256 bits).
+  - At the time of writing, YASMF only contains the BLAKE3 hash, which therefore is the hash function used throughout p2panda. It is fast, safe, and produces hashes that are just 32 bytes long.
 
 ### Encoding
 

--- a/website/docs/specification/data-types/bamboo.md
+++ b/website/docs/specification/data-types/bamboo.md
@@ -33,14 +33,6 @@ p2panda uses [Bamboo][bamboo_spec] with Ed25519 (Digital Signature Algorithm) an
   - YASMF has the additional requirement that hash functions should be chosen that produce shorter hashes of 256 bits.
   - At the time of writing, YASMF only contains the Blake3b hash, which therefore is the hash function used throughout p2panda. It is fast, safe, and produces hashes that are just 32 bytes long.
 
-### Signatures
-
-:::caution Requirement KY1
-
-Clients MUST use Ed25519 as the Digital Signature Algorithm for Bamboo.
-
-:::
-
 ### Encoding
 
 :::caution Requirement BA3
@@ -62,6 +54,7 @@ A p2panda author is a human or bot who publishes data using p2panda. Authors may
 - Data published using Bamboo always belongs to the public key that signed it, this key is called _author_ in Bamboo.
 - People and bots who use p2panda can have access to more than one key pair, which is why we don't call public keys _author_, as Bamboo does, we call them _public key_.
   - Data in p2panda belongs to the _key pair_ that signed it.
+  - p2panda uses Ed25519 as the Bamboo signature scheme.
   - p2panda users may have more than one key because every device and client uses an additional key.
 - Have a look at the [key pairs][key_pairs] section of this handbook for more detailed information on this topic.
 

--- a/website/docs/specification/data-types/key-pairs.md
+++ b/website/docs/specification/data-types/key-pairs.md
@@ -5,18 +5,16 @@ title: Key Pairs
 
 :::caution Requirement KY1
 
-Key pairs MUST use ED25519 keys.
+Clients MUST use Ed25519 as the Digital Signature Algorithm for Bamboo.
 
 :::
-
-Correct hexadecimal encoding (when using human-readable encoding format) (#OP1)
 
 - A key pair is used to sign Bamboo entries and their payloads.
 - The public key of a key pair is embedded in Bamboo entries and therefore always available when verifying an entry and its payload.
 
 ## Usage
 
-- p2panda clients create key pairs for their users
+- p2panda clients create key pairs for their users.
 - Data recipients can identify the author of data from the public key and the signature on a [bamboo entry](/specification/data-types/bamboo#entries).
   - The public key and signature are distributed alongside the data.
 - Data recipients can verify the integrity of data using the signature on bamboo entries.
@@ -45,3 +43,6 @@ p2panda clients SHOULD NOT require the transmission of a private key outside a u
 :::
 
 - Transmitting a private key outside of its usage context might be attractive e.g. to migrate a software installation but it is considered a security risk, can lead to forks and hard to get right in terms of user experience.
+- To migrate data clients should rather make use of p2panda [Key Groups][key_groups], by transferring the permissions to a new key pair instead of migrating the old key pair itself
+
+[key_groups]: /specification/core-concepts/permissions


### PR DESCRIPTION
- Not everything is an "Encoding" :-D
- Bamboo is generic over the DSA and Hashing scheme, the latter is mentioned, I've written a little bit more about the first
- BLAKE3 instead of BLAKE3b (latter does not exist)
- Multifactor typo
- We do _not_ require Bamboo entries to be hexadecimal encoded, _except_ of in the GraphQL API