### PR TITLE
Change CBOR link on send-to-node tutorial

### DIFF
--- a/website/docs/tutorials/send-to-node.md
+++ b/website/docs/tutorials/send-to-node.md
@@ -56,7 +56,7 @@ A fun exercise could be to try implement `send-to-node` in JavaScript with the [
 
 :::note Why JSON?
 
-p2panda does not use JSON internally, even though `send-to-node` works with `.json` files. It is just the choosen format for this program to create operations. Internally all operations are actually encoded as [CBOR](http://localhost:3000/specification/data-types/operations#encoding-format).
+p2panda does not use JSON internally, even though `send-to-node` works with `.json` files. It is just the choosen format for this program to create operations. Internally all operations are actually encoded as [CBOR](/specification/data-types/operations/#encoding-format).
 
 :::
 


### PR DESCRIPTION
The previous link was `http://localhost:3000/specification/data-types/operations#encoding-format` Based on other links I changed it to `/specification/data-types/operations/#encoding-format`