### PR TITLE
Update graphql tutorial examples to use 'document' subobject

### DIFF
--- a/website/docs/tutorials/aquadoggo.md
+++ b/website/docs/tutorials/aquadoggo.md
@@ -118,9 +118,11 @@ Try this following query by entering it in the left textarea and clicking the _P
 ```graphql
 {
   all_schema_definition_v1 {
-    fields {
-      name
-      description
+    document {
+      fields {
+        name
+        description
+      }
     }
   }
 }

--- a/website/docs/tutorials/send-to-node.md
+++ b/website/docs/tutorials/send-to-node.md
@@ -248,16 +248,18 @@ By the way, in p2panda it is important to have [multiple keys](/specification/da
 
 We've created a new field now, so we can also directly inspect it via the GraphQL playground of the `aquadoggo` node. For this you can just surf to [http://localhost:2020/graphql](http://localhost:2020/graphql) and run the following query in the left area:
 
-```
+```graphql
 {
   all_schema_field_definition_v1 {
-    meta {
-      documentId
-    }
-    fields {
-      name
-      type
-    }
+    document {
+      meta {
+        documentId
+      }
+      fields {
+        name
+        type
+      }
+   }
   }
 }
 ```
@@ -450,16 +452,18 @@ We're already having the schema id and we can insert it into `005-update-message
 
 Again, the GraphQL playground can help us here. We can simply just query all chat messages and ask for their regarding `viewId` with the following query:
 
-```
+```graphql
 {
   all_<insert your schema id here> {
-    meta {
-      documentId
-      viewId
-    }
-    fields {
-      message
-      timestamp
+    document {
+      meta {
+        documentId
+        viewId
+      }
+      fields {
+        message
+        timestamp
+      }
     }
   }
 }


### PR DESCRIPTION
The example graphql blocks in the first two tutorials were missing `document { }` wrappers that seem to be standard now. Otherwise you get graphql errors when following along.