### PR TITLE
Aquadoggo tutorial needs a section to copy the config file

### DIFF
--- a/website/docs/tutorials/aquadoggo.md
+++ b/website/docs/tutorials/aquadoggo.md
@@ -48,6 +48,17 @@ git clone https://github.com/p2panda/aquadoggo.git
 cd aquadoggo
 ```
 
+## Copy the sample config file
+
+Aquadoggo has a configuration file to tell it how to work. Even though you cloned autodoggo from git, the config file is excluded from git so that you can modify it yourself. However, you do need something to get you started, so you'll need to make a copy of the example config file.
+
+```bash
+# Copy the example config file
+cp ./aquadoggo_cli/example_config.toml ./config.toml
+```
+
+You can make changes inside your new config.toml file if you want, but for now we just need the defaults.
+
 ## Start the node
 
 To run the node now you only have to run this command inside the project's folder:
@@ -65,7 +76,7 @@ When the compilation finished and the program started you will see .. almost not
      Running `target/debug/aquadoggo`
 ```
 
-This is because by default the program will not spit out any information except when you explicitly asked about it. 
+This is because by default the program will not spit out any information except when you explicitly asked about it.
 
 The node is already running, you are done!
 


### PR DESCRIPTION
Hi, I'm a new user and working through the tutorials from scratch, on a fresh machine.

I found that following the tutorial as it stood I got mysterious errors logged:

```
[2023-08-05T02:13:12Z DEBUG aquadoggo::node] Schema not added to schema provider: not supported schema_definition_v1
[2023-08-05T02:13:12Z DEBUG aquadoggo::node] Schema not added to schema provider: not supported schema_field_definition_v1
```
The node also didn't support the query for all_schemas which is used as the example in this tutorial to prove everything was working. And finally, it was impossible to start on the next tutorial and create schemas.

The solution is to copy the example config file. This PR pops that into the tutorial, before the run stage (to avoid asking them to copy the config and then restart the node).

Feel free to completely rewrite, but as a new user this was a hard thing to spot, I noticed the addition of the config file by searching recent PRs.